### PR TITLE
Milestone 1B Redo with README update

### DIFF
--- a/real_preprocessing/README.md
+++ b/real_preprocessing/README.md
@@ -10,16 +10,12 @@
 
 	find_package(find_package(OpenCV REQUIRED PATHS "YOUR-FOLDER-PATH")
 
-### Camera calibration
-The package requires calibration of the camera to be used. This was done using [camera\_calibration](http://wiki.ros.org/camera_calibration).  The intrinsics obtained should be recorded as it is required for detection accuracy. Your intrinsic matrix, K, must be specified in **corner\_detection.cpp**, specifically at line 18,  `intrinsic << #, #, #, #, #, #, #, #, #;`.
-
 ### Image publishing 
-**corner\_detection.cpp** simulates image capture with user input. By default, `""` /`ENTER` is the assigned trigger for image processing and YAML dumping. The YAML file for each frame detection is dumped at the working directory. To view the video stream detection, [image\_view](http://wiki.ros.org/image_view) was the library included. Rviz can be used alternatively with some configuration.
+**corner\_detection.cpp** simulates image capture with user input. By default, `""` /`ENTER` is the assigned trigger for image processing and YAML dumping. The YAML file for each frame detection is dumped at the working directory named "detection_n.yml" for the nth image taken. To view the video stream detection, [image\_view](http://wiki.ros.org/image_view) was the library included. Rviz can be used alternatively with some configuration.
 
 ### Steps: 
 	1.  $ roscore 
-	2.  $ rosparam load ~/.ros/camera_info/camera.yaml
-	3.  $ rosrun cv_camera cv_camera_node 
-	4.  $ roslaunch apriltag_ros continuous_detection.launch camera_name:=/cv_camera image_topic:=image_raw 
-	5.  $ rosrun image_view image_view image:=tag_detections_image
-	6.  $ rosrun real_preprocessing corner_detection_node
+	2.  $ rosrun cv_camera cv_camera_node 
+	3.  $ roslaunch apriltag_ros continuous_detection.launch camera_name:=/cv_camera image_topic:=image_raw 
+	4.  $ rosrun image_view image_view image:=tag_detections_image
+	5.  $ rosrun real_preprocessing corner_detection_node

--- a/real_preprocessing/src/camera_pose.cpp
+++ b/real_preprocessing/src/camera_pose.cpp
@@ -1,0 +1,228 @@
+#include "ros/ros.h"
+#include "fstream"
+#include "opencv2/opencv.hpp"
+#include "yaml-cpp/yaml.h"
+#include "string"
+#include "Eigen/Dense"
+#include "algorithm"
+#include "std_msgs/Int32.h"
+
+using namespace cv;
+
+int world, world_loc, known_loc;
+std::vector<int> w_T_tags_id;
+std::vector<int> unknown_file;
+std::vector<Eigen::MatrixXd> w_T_tags_trans;
+Eigen::MatrixXd obj_T_cam(4, 4);
+Eigen::MatrixXd w_T_cam(4, 4);
+Eigen::MatrixXd w_T_tag(4, 4);
+cv::Mat cam_matrix(3,3,CV_64FC1);
+cv::Vec<float, 5> distCoeffs;
+
+//loads camera inrtrinsics from rosparam server
+void intrinsicLoad()
+{
+  ros::NodeHandle NH;
+  std::vector<double> intrinsic;
+  NH.getParam("/camera_matrix/data", intrinsic);
+  memcpy(cam_matrix.data,intrinsic.data(),intrinsic.size()*sizeof(double));
+  NH.getParam("/distortion_coefficients/data", intrinsic);
+  distCoeffs={intrinsic[0],intrinsic[1],intrinsic[2],intrinsic[3],intrinsic[4]};
+}
+
+//solvePnP calculator given file number and tag position in file
+void objTcam(int loc, int filenum)
+{
+  YAML::Node tags_pix = YAML::LoadFile("detections_" + std::to_string(filenum) + ".yml");
+  int tl_pix_x = tags_pix["detections"][loc]["corners"]["0"][0].as<int>();
+  int tl_pix_y = tags_pix["detections"][loc]["corners"]["0"][1].as<int>();
+  int tr_pix_x = tags_pix["detections"][loc]["corners"]["1"][0].as<int>();
+  int tr_pix_y = tags_pix["detections"][loc]["corners"]["1"][1].as<int>();
+  int br_pix_x = tags_pix["detections"][loc]["corners"]["2"][0].as<int>();
+  int br_pix_y = tags_pix["detections"][loc]["corners"]["2"][1].as<int>();
+  int bl_pix_x = tags_pix["detections"][loc]["corners"]["3"][0].as<int>();
+  int bl_pix_y = tags_pix["detections"][loc]["corners"]["3"][1].as<int>();
+  int tag_id = tags_pix["detections"][loc]["TargetID"].as<int>();
+  double tag_size = tags_pix["detections"][loc]["size"].as<double>();
+
+  std::vector<cv::Point2d> img_pts;
+  std::vector<cv::Point3d> obj_pts;
+  cv::Mat rodrigues_rvec;
+  cv::Mat obj_T_cam_rvec;
+  cv::Mat obj_T_cam_tvec;
+
+  img_pts.push_back(cv::Point2d(tl_pix_x, tl_pix_y));
+  img_pts.push_back(cv::Point2d(tr_pix_x, tr_pix_y));
+  img_pts.push_back(cv::Point2d(br_pix_x, br_pix_y));
+  img_pts.push_back(cv::Point2d(bl_pix_x, bl_pix_y));
+
+  //object corner specification
+  obj_pts.push_back(cv::Point3d(-(tag_size / 2), (tag_size / 2), 0));
+  obj_pts.push_back(cv::Point3d((tag_size / 2), (tag_size / 2), 0));
+  obj_pts.push_back(cv::Point3d((tag_size / 2), -(tag_size / 2), 0));
+  obj_pts.push_back(cv::Point3d(-(tag_size / 2), -(tag_size / 2), 0));
+
+  cv::solvePnP(obj_pts, img_pts, cam_matrix, distCoeffs, rodrigues_rvec, obj_T_cam_tvec, false, CV_ITERATIVE);
+  cv::Rodrigues(rodrigues_rvec, obj_T_cam_rvec); //rotational matrix conversion
+
+  obj_T_cam << obj_T_cam_rvec.at<double>(0, 0), obj_T_cam_rvec.at<double>(0, 1), obj_T_cam_rvec.at<double>(0, 2),
+      obj_T_cam_tvec.at<double>(0, 0), obj_T_cam_rvec.at<double>(1, 0), obj_T_cam_rvec.at<double>(1, 1),
+      obj_T_cam_rvec.at<double>(1, 2), obj_T_cam_tvec.at<double>(0, 1), obj_T_cam_rvec.at<double>(2, 0),
+      obj_T_cam_rvec.at<double>(2, 1), obj_T_cam_rvec.at<double>(2, 2), obj_T_cam_tvec.at<double>(0, 2), 0, 0, 0, 1;
+}
+
+//Calculates w_T_tag for all unknown tags in a file with the world tag present
+void calcWorld(int filenum)
+{
+  YAML::Node tags_pix = YAML::LoadFile("detections_" + std::to_string(filenum) + ".yml");
+  for (int i = 0; i < tags_pix["detections"].size(); ++i)
+  {
+    if (i != world_loc)
+    {
+      objTcam(i, filenum);
+      w_T_tag = w_T_cam * obj_T_cam.inverse();
+      w_T_tags_trans.push_back(w_T_tag);
+      w_T_tags_id.push_back(tags_pix["detections"][i]["TargetID"].as<int>());
+    }
+  }
+}
+
+//Calculates w_T_tag for all unknown tags in a file with one or more known tags
+void calcKnown(int filenum)
+{
+  YAML::Node tags_pix = YAML::LoadFile("detections_" + std::to_string(filenum) + ".yml");
+  std::vector<int>::iterator it = std::find(w_T_tags_id.begin(), w_T_tags_id.end(), tags_pix["detections"][known_loc]["TargetID"].as<int>());
+  int index = std::distance(w_T_tags_id.begin(), it);
+  objTcam(known_loc, filenum);
+  w_T_cam = w_T_tags_trans[index] * obj_T_cam;
+  for (int i = 0; i < tags_pix["detections"].size(); ++i)
+  {
+    if ((i != known_loc) &&
+        ((std::find(w_T_tags_id.begin(), w_T_tags_id.end(), tags_pix["detections"][i]["TargetID"].as<int>()) !=
+          w_T_tags_id.end()) == false))
+    {
+      objTcam(i, filenum);
+      w_T_tag = w_T_cam * obj_T_cam.inverse();
+      w_T_tags_trans.push_back(w_T_tag);
+      w_T_tags_id.push_back(tags_pix["detections"][i]["TargetID"].as<int>());
+    }
+  }
+}
+
+//Returns status of file : world tag present, known tag present, all unknown tags, no file
+int fileReader(int filenum)
+{
+  bool known_tag(0);
+  std::ifstream fin;
+  fin.open("detections_" + std::to_string(filenum) + ".yml");
+  if (fin.is_open())
+  {
+    fin.close();
+    YAML::Node tags_pix = YAML::LoadFile("detections_" + std::to_string(filenum) + ".yml");
+    if (filenum == 0)
+    {
+      world = tags_pix["detections"][0]["TargetID"].as<int>(); //world tag chosen in first file/first tag listing
+      objTcam(0, 0);
+      world_loc = 0;
+      return 0;
+    }
+    for (int i = 0; i < tags_pix["detections"].size(); ++i)
+    {
+      if (std::find(w_T_tags_id.begin(), w_T_tags_id.end(), tags_pix["detections"][i]["TargetID"].as<int>()) !=w_T_tags_id.end())
+      {
+        known_tag = 1;
+        known_loc = i;
+      }
+      if (tags_pix["detections"][i]["TargetID"].as<int>() == world)
+      {
+        objTcam(i, filenum);
+        world_loc = i;
+        return 0;
+      }
+    }
+    if (known_tag == 1)
+    {
+      return 1;
+    }
+    else
+      return 2;
+  }
+  else
+    return 3;
+}
+
+void posePublish(ros::Publisher pub,std_msgs::Int32 msg, int n)
+{
+  msg.data=n;
+  pub.publish(msg);
+}
+
+void fileStream(ros::Publisher pub,std_msgs::Int32 msg)
+{
+  int file(0);//need to come out to update for each new snapshot
+  do
+  {
+    if (fileReader(file) != 3)
+    {
+      if (fileReader(file) == 0) //world tag present
+      {
+        w_T_cam = obj_T_cam;
+        ROS_INFO("\n");
+        ROS_INFO("world_T_cam for file %i:", file);
+        ROS_INFO_STREAM(w_T_cam);
+        calcWorld(file);
+      }
+      if (fileReader(file) == 1) // known tag present
+      {
+        calcKnown(file);
+        ROS_INFO("\n");
+        ROS_INFO("world_T_cam for file %i:", file);
+        ROS_INFO_STREAM(w_T_cam);
+        if (unknown_file.size() != 0) //polling for unprocessed files to be reread 
+        {
+          for (int i = (unknown_file.size() - 1); i >= 0; i--)
+          {
+            if (fileReader(unknown_file[i]) == 1)
+            {
+              calcKnown(unknown_file[i]);
+              unknown_file.erase(unknown_file.begin() + i);
+            }
+          }
+        }
+      }
+      if (fileReader(file) == 2) //all unknown tags
+      {
+        unknown_file.push_back(file); //records file with all unknown tags
+        ROS_INFO("File detections_%i.yml has no known tags!", file);
+      }
+      file++;
+    }
+    if (fileReader(file) == 3) //no file - end of file count
+    {
+      ROS_INFO("Files processed: %i", file);
+      for (int i=0;i!=w_T_tags_id.size();i++)
+      {
+        ROS_INFO_STREAM(w_T_tags_id[i]);
+      }
+    }
+    posePublish(pub,msg,file);///////
+  } while (fileReader(file) != 3);
+  while (fileReader(file)==3)
+  {
+    posePublish(pub,msg,6);////////
+    ROS_INFO_STREAM(file);
+  }
+
+}
+
+ int main(int argc, char** argv)
+ {
+  ros::init(argc, argv, "camera_pose");
+  ros::NodeHandle nh;
+  ros::Publisher pub=nh.advertise<std_msgs::Int32>("NAME", 1);
+  std_msgs::Int32 msg;
+  intrinsicLoad();
+  while(ros::ok)  
+  fileStream(pub,msg);
+  return 0;
+}


### PR DESCRIPTION
Removed all intrinsic calculations as the apriltag_ros library was altered to include intrinsic free pixel coordinates. So milestone 1b is now simply a subscriber which dumps these pixels into the same format YAML files. The snapshot simulator works the same and the README accounts for the removal of calibration dependence. 